### PR TITLE
#30 Implemented a new way for taking paths from registry in Windows

### DIFF
--- a/filesystem/__init__.py
+++ b/filesystem/__init__.py
@@ -129,27 +129,33 @@ elif PLATFORM == "darwin":
     """
 elif PLATFORM == "win32" or PLATFORM == "win64":
     PLATFORM_NAME = "Windows"
+    import winreg
+    def get_registry_paths(folder_name):
+        sub_key = r'SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Shell Folders'
+        with winreg.OpenKey(winreg.HKEY_CURRENT_USER, sub_key) as key:
+            return winreg.QueryValueEx(key, folder_name)[0]
+    
     user = os.environ['USERPROFILE']
     """
     Creates a string that represents the path to the current user's home directory.
     """
-    desktop = f'{user}/Desktop'
+    desktop = get_registry_paths("Desktop")
     """
     Creates a string that represents the path to the current user's Desktop folder.
     """
-    documents = f'{user}/Documents'
+    documents = get_registry_paths("Personal")
     """
     Creates a string that represents the path to the current user's Documents folder.
     """
-    downloads = f'{user}/Downloads'
+    downloads = get_registry_paths("{374DE290-123F-4565-9164-39C4925E467B}")
     """
     Creates a string that represents the path to the current user's Downloads folder.
     """
-    music = f'{user}/Music'
+    music = get_registry_paths("My Music")
     """
     Creates a string that represents the path to the current user's Music folder.
     """
-    pictures = f'{user}/Pictures'
+    pictures = get_registry_paths("My Pictures")
     """
     Creates a string that represents the path to the current user's Pictures folder.
     """
@@ -157,7 +163,7 @@ elif PLATFORM == "win32" or PLATFORM == "win64":
     """
     Creates a string that represents the path to the current user's Public folder.
     """
-    videos = f'{user}/Videos'
+    videos = get_registry_paths("My Video")
     """
     Creates a string that represents the path to the current user's Videos folder.
     """
@@ -176,7 +182,7 @@ Creates a string that represents the path to the current user's Movies folder in
 
 - Tip: Use `fs.videos` instead:
 
-```
+```python
 import filesystem as fs
 print(fs.videos)
 ```


### PR DESCRIPTION
# FileSystem Module

---

## Overview

This commit provides an overview of the recent changes made to the `FileSystem` module, specifically for the Windows platform. The code has been updated to retrieve user folder paths using the Windows registry instead of environment variables.

## Changes Made

### Previous Implementation

In the previous implementation, the paths to user folders (Desktop, Documents, Downloads, Music, Pictures, Public, Videos) were retrieved using environment variables:

### Updated Implementation

In the updated implementation, the paths to user folders are retrieved using the Windows registry:

### Benefits of the Updated Implementation

- **Accuracy:** Retrieving paths from the Windows registry ensures that the correct and current paths are used.
- **Consistency:** The updated implementation provides a consistent method for retrieving user folder paths across different versions of Windows.

### Example Usage

The following example demonstrates how to access the Videos folder using the updated FileSystem module:

```python
import filesystem as fs
print(fs.videos)
```

These changes were made to enhance the accuracy and reliability of the FileSystem module. We appreciate your continued support and feedback, which are essential for these improvements.